### PR TITLE
Update manifest.json allowing installation with Zotero 9.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
             "id": "quicklook@zotero-plugin.org",
             "update_url": "https://raw.githubusercontent.com/gchapron/zotero7quicklook/main/update.json",
             "strict_min_version": "6.999",
-            "strict_max_version": "8.0.*"
+            "strict_max_version": "9.0.*"
         }
     }
 }


### PR DESCRIPTION
Increasing Maximum Version supported. Tested with Zotero 9.0 on macOS Tahoe 26.4.1